### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "images"
   ],
   "description": "Copies images + annotations + images metadata",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "images"
   ],
   "description": "Copies images + annotations + images metadata",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -20,5 +20,5 @@
   "icon": "https://img.icons8.com/color/96/000000/networking-manager.png",
   "icon_background": "#FFFFFF",
   "poster": "https://user-images.githubusercontent.com/48245050/182578921-e47cdecb-5726-424d-a1c9-b06dbf692b1f.png",
-  "min_instance_version": "6.11.8"
+  "instance_version": "6.15.60"
 }

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "images"
   ],
   "description": "Copies images + annotations + images metadata",
-  "docker_image": "supervisely/import-export:6.73.162",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.162
+supervisely==6.73.564

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 import os
-import supervisely_lib as sly
+import supervisely as sly
 
 TEAM_ID = int(os.environ['context.teamId'])
 WORKSPACE_ID = int(os.environ['context.workspaceId'])


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
